### PR TITLE
feat: implement agentic targeting pipeline

### DIFF
--- a/backend/agentic_pipeline/__init__.py
+++ b/backend/agentic_pipeline/__init__.py
@@ -1,0 +1,3 @@
+"""Agentic targeting pipeline package."""
+
+__all__ = []

--- a/backend/agentic_pipeline/analysis.py
+++ b/backend/agentic_pipeline/analysis.py
@@ -1,0 +1,106 @@
+"""Market and financial analysis generators."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import pandas as pd
+
+
+@dataclass(slots=True)
+class AnalysisResult:
+    market_summary: pd.Series
+    financial_summary: pd.Series
+    risk_flags: pd.Series
+
+
+class MarketFinancialAnalyzer:
+    """Generates deterministic summaries using engineered data."""
+
+    def __init__(self, language: str = "en") -> None:
+        self.language = language
+
+    def _format_currency(self, value: float) -> str:
+        if pd.isna(value):
+            return "unknown revenue"
+        if value >= 1_000_000_000:
+            return f"{value/1_000_000_000:.1f}B SEK"
+        if value >= 1_000_000:
+            return f"{value/1_000_000:.1f}M SEK"
+        if value >= 1_000:
+            return f"{value/1_000:.1f}k SEK"
+        return f"{value:,.0f} SEK"
+
+    def _categorize_growth(self, growth: float) -> str:
+        if pd.isna(growth):
+            return "stable"
+        if growth > 0.35:
+            return "hyper-growth"
+        if growth > 0.15:
+            return "high growth"
+        if growth > 0.05:
+            return "moderate growth"
+        if growth >= 0:
+            return "flat"
+        return "contracting"
+
+    def _categorize_margin(self, margin: float, label: str) -> str:
+        if pd.isna(margin):
+            return f"{label} margin unavailable"
+        if margin > 0.2:
+            return f"strong {label} margin"
+        if margin > 0.1:
+            return f"healthy {label} margin"
+        if margin > 0:
+            return f"thin {label} margin"
+        return f"negative {label} margin"
+
+    def _risk_assessment(self, equity_ratio: float, revenue_growth: float) -> str:
+        flags: list[str] = []
+        if pd.isna(equity_ratio) or equity_ratio < 0.25:
+            flags.append("low equity cushion")
+        if pd.isna(revenue_growth) or revenue_growth < 0:
+            flags.append("declining topline")
+        return "; ".join(flags) if flags else "no immediate red flags"
+
+    def analyze(self, dataset: pd.DataFrame) -> AnalysisResult:
+        market_summaries = []
+        financial_summaries = []
+        risk_flags = []
+
+        for _, row in dataset.iterrows():
+            revenue = row.get("revenue")
+            growth = row.get("revenue_growth")
+            ebit_margin = row.get("ebit_margin")
+            net_margin = row.get("net_margin")
+            employees = row.get("employees")
+            segment = row.get("segment_name") or row.get("Segment") or "General"
+
+            revenue_text = self._format_currency(revenue)
+            growth_text = self._categorize_growth(growth)
+
+            market_summary = (
+                f"{segment} company with {growth_text} trajectory and "
+                f"{revenue_text} in latest reported revenue."
+            )
+            market_summaries.append(market_summary)
+
+            ebit_text = self._categorize_margin(ebit_margin, "EBIT")
+            net_text = self._categorize_margin(net_margin, "net")
+            headcount_text = "lean team" if employees and employees < 20 else "scaled workforce"
+            financial_summary = (
+                f"Operates with {ebit_text}, {net_text}, and a {headcount_text} of {int(employees) if pd.notna(employees) else 'unknown'} employees."
+            )
+            financial_summaries.append(financial_summary)
+
+            risk_flags.append(self._risk_assessment(row.get("equity_ratio"), growth))
+
+        return AnalysisResult(
+            market_summary=pd.Series(market_summaries, index=dataset.index, name="market_summary"),
+            financial_summary=pd.Series(financial_summaries, index=dataset.index, name="financial_summary"),
+            risk_flags=pd.Series(risk_flags, index=dataset.index, name="risk_flags"),
+        )
+
+
+__all__ = ["MarketFinancialAnalyzer", "AnalysisResult"]

--- a/backend/agentic_pipeline/config.py
+++ b/backend/agentic_pipeline/config.py
@@ -1,0 +1,63 @@
+"""Configuration models for the agentic targeting pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Sequence
+
+
+@dataclass(slots=True)
+class SegmentWeighting:
+    """Weight configuration for ranking components."""
+
+    growth: float = 0.35
+    profitability: float = 0.25
+    efficiency: float = 0.2
+    risk: float = 0.1
+    data_quality: float = 0.1
+
+    def as_sequence(self) -> Sequence[float]:
+        return [
+            self.growth,
+            self.profitability,
+            self.efficiency,
+            self.risk,
+            self.data_quality,
+        ]
+
+
+@dataclass(slots=True)
+class PipelineConfig:
+    """Top-level configuration for the targeting pipeline."""
+
+    db_path: Path = Path("allabolag.db")
+    shortlist_table: str = "target_company_shortlist"
+    shortlist_view_versioned_prefix: str = "target_company_shortlist_v"
+    feature_columns: List[str] = field(
+        default_factory=lambda: [
+            "revenue",
+            "revenue_growth",
+            "ebit_margin",
+            "net_margin",
+            "employees",
+            "revenue_per_employee",
+            "ebit_per_employee",
+            "assets",
+            "equity_ratio",
+        ]
+    )
+    ranking_weights: SegmentWeighting = field(default_factory=SegmentWeighting)
+    n_top_companies: int = 30
+    output_dir: Path = Path("outputs/agentic")
+    write_to_db: bool = True
+    write_to_csv: bool = True
+    write_to_excel: bool = True
+    excel_filename: str = "agentic_shortlist.xlsx"
+    csv_filename: str = "agentic_shortlist.csv"
+
+    def ensure_output_dirs(self) -> None:
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+
+__all__ = ["PipelineConfig", "SegmentWeighting"]

--- a/backend/agentic_pipeline/data_access.py
+++ b/backend/agentic_pipeline/data_access.py
@@ -1,0 +1,70 @@
+"""Data loading utilities for the agentic targeting pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+import pandas as pd
+from sqlalchemy import create_engine, inspect
+
+
+REQUIRED_TABLES: Iterable[str] = (
+    "company_kpis",
+    "company_accounts",
+    "companies_enriched",
+)
+
+
+@dataclass(slots=True)
+class DataLoadResult:
+    """Container for merged dataset and diagnostics."""
+
+    dataset: pd.DataFrame
+    issues: list[str]
+
+
+class TargetingDataLoader:
+    """Loads and merges company datasets from SQLite or Supabase mirrors."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self.engine = create_engine(f"sqlite:///{db_path}")
+
+    def validate_tables(self) -> list[str]:
+        inspector = inspect(self.engine)
+        available = set(inspector.get_table_names())
+        missing = [table for table in REQUIRED_TABLES if table not in available]
+        return missing
+
+    def load_latest_by_year(self, table: str, key_columns: Iterable[str]) -> pd.DataFrame:
+        df = pd.read_sql_table(table, self.engine)
+        if df.empty:
+            return df
+        idx = df.groupby(list(key_columns))["year"].idxmax()
+        return df.loc[idx].reset_index(drop=True)
+
+    def load(self) -> DataLoadResult:
+        issues: list[str] = []
+        missing = self.validate_tables()
+        if missing:
+            issues.append(f"Missing required tables: {', '.join(missing)}")
+            return DataLoadResult(pd.DataFrame(), issues)
+
+        kpis = self.load_latest_by_year("company_kpis", ["OrgNr"])
+        accounts = self.load_latest_by_year("company_accounts", ["OrgNr"])
+        enriched = pd.read_sql_table("companies_enriched", self.engine)
+
+        if kpis.empty or accounts.empty or enriched.empty:
+            issues.append("One or more source tables are empty.")
+            return DataLoadResult(pd.DataFrame(), issues)
+
+        merged = kpis.merge(accounts, on=["OrgNr", "year"], suffixes=("_kpi", "_acc"))
+        merged = merged.merge(enriched, on="OrgNr", how="left", suffixes=(None, None))
+        merged = merged.drop_duplicates(subset=["OrgNr"]).reset_index(drop=True)
+
+        return DataLoadResult(merged, issues)
+
+
+__all__ = ["TargetingDataLoader", "DataLoadResult"]

--- a/backend/agentic_pipeline/features.py
+++ b/backend/agentic_pipeline/features.py
@@ -1,0 +1,87 @@
+"""Feature engineering utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(slots=True)
+class FeatureEngineeringResult:
+    features: pd.DataFrame
+    feature_metadata: dict[str, dict[str, float]]
+
+
+class FeatureEngineer:
+    """Computes engineered features for segmentation and ranking."""
+
+    def __init__(self, required_columns: Iterable[str] | None = None) -> None:
+        self.required_columns = set(required_columns or [])
+
+    def _safe_ratio(self, numerator: pd.Series, denominator: pd.Series) -> pd.Series:
+        return numerator.astype(float).fillna(0.0) / denominator.replace({0: np.nan}).astype(float)
+
+    def transform(self, df: pd.DataFrame) -> FeatureEngineeringResult:
+        frame = df.copy()
+        frame.rename(
+            columns={
+                "SDI": "revenue",
+                "DR": "ebit",
+                "ORS": "net_income",
+                "AntalAnstallda": "employees",
+                "Omsattning": "revenue",
+            },
+            inplace=True,
+        )
+
+        if "employees" not in frame and "employees" in frame.columns:
+            frame["employees"] = frame["employees"].fillna(0)
+
+        frame["revenue"] = frame[[col for col in frame.columns if col.lower() == "revenue" or col == "SDI"]].iloc[:, 0]
+        frame["revenue_growth"] = frame.get("Revenue_growth", frame.get("RevenueGrowth", pd.Series(dtype=float)))
+        frame["ebit_margin"] = frame.get("EBIT_margin", frame.get("EBITMargin", pd.Series(dtype=float)))
+        frame["net_margin"] = frame.get("NetProfit_margin", frame.get("NetProfitMargin", pd.Series(dtype=float)))
+        frame["employees"] = frame.get("employees", frame.get("AntalAnstallda", pd.Series(dtype=float))).fillna(0)
+        frame["ebit"] = frame.get("ebit", frame.get("EBIT", pd.Series(dtype=float))).fillna(0)
+        frame["assets"] = frame.get("TotalaTillgangar", pd.Series(dtype=float)).fillna(0)
+        frame["equity"] = frame.get("EgetKapital", pd.Series(dtype=float)).fillna(0)
+
+        frame["revenue_per_employee"] = self._safe_ratio(frame["revenue"], frame["employees"]).fillna(0)
+        frame["ebit_per_employee"] = self._safe_ratio(frame["ebit"], frame["employees"]).fillna(0)
+        frame["equity_ratio"] = self._safe_ratio(frame["equity"], frame["assets"]).fillna(0)
+
+        numeric_cols = [
+            "revenue",
+            "revenue_growth",
+            "ebit_margin",
+            "net_margin",
+            "employees",
+            "revenue_per_employee",
+            "ebit_per_employee",
+            "assets",
+            "equity_ratio",
+        ]
+
+        engineered = frame[numeric_cols].apply(pd.to_numeric, errors="coerce").fillna(0)
+
+        metadata: dict[str, dict[str, float]] = {}
+        for column in numeric_cols:
+            series = engineered[column]
+            metadata[column] = {
+                "mean": float(series.mean()),
+                "std": float(series.std(ddof=0)),
+                "min": float(series.min()),
+                "max": float(series.max()),
+            }
+
+        missing_required = self.required_columns.difference(engineered.columns)
+        if missing_required:
+            raise ValueError(f"Missing required engineered features: {', '.join(sorted(missing_required))}")
+
+        return FeatureEngineeringResult(engineered, metadata)
+
+
+__all__ = ["FeatureEngineer", "FeatureEngineeringResult"]

--- a/backend/agentic_pipeline/orchestrator.py
+++ b/backend/agentic_pipeline/orchestrator.py
@@ -1,0 +1,94 @@
+"""Agentic pipeline orchestrator coordinating segmentation and analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+import pandas as pd
+
+from .analysis import MarketFinancialAnalyzer
+from .config import PipelineConfig
+from .data_access import TargetingDataLoader
+from .features import FeatureEngineer
+from .quality import DataQualityChecker
+from .ranking import CompositeRanker
+from .segmentation import Segmenter
+
+
+@dataclass(slots=True)
+class PipelineArtifacts:
+    dataset: pd.DataFrame
+    features: pd.DataFrame
+    shortlist: pd.DataFrame
+    quality_issues: list
+
+
+class AgenticTargetingPipeline:
+    """Coordinates the end-to-end selection workflow."""
+
+    def __init__(self, config: PipelineConfig) -> None:
+        self.config = config
+        self.loader = TargetingDataLoader(config.db_path)
+        self.feature_engineer = FeatureEngineer(required_columns=config.feature_columns)
+        self.quality_checker = DataQualityChecker(required_columns=config.feature_columns)
+        self.segmenter = Segmenter()
+        self.ranker = CompositeRanker(config.ranking_weights)
+        self.analyzer = MarketFinancialAnalyzer()
+
+    def run(self) -> PipelineArtifacts:
+        self.config.ensure_output_dirs()
+
+        load_result = self.loader.load()
+        dataset = load_result.dataset
+        quality_issues = load_result.issues
+
+        if dataset.empty:
+            raise RuntimeError("Dataset is empty; cannot proceed with pipeline.")
+
+        engineered = self.feature_engineer.transform(dataset)
+        quality_issues.extend(self.quality_checker.run(engineered.features))
+
+        segmentation = self.segmenter.fit_predict(engineered.features[self.config.feature_columns])
+        dataset = dataset.join(segmentation.labels)
+
+        ranking = self.ranker.score(engineered.features[self.config.feature_columns])
+        dataset = dataset.join(ranking.scores)
+        dataset = dataset.join(ranking.components.add_prefix("score_component_"))
+
+        analysis = self.analyzer.analyze(dataset)
+        dataset = dataset.join(analysis.market_summary)
+        dataset = dataset.join(analysis.financial_summary)
+        dataset = dataset.join(analysis.risk_flags)
+
+        shortlist = dataset.sort_values("composite_score", ascending=False).head(self.config.n_top_companies)
+        shortlist = shortlist.reset_index(drop=True)
+
+        self._persist(shortlist, segmentation.cluster_centers)
+
+        return PipelineArtifacts(
+            dataset=dataset,
+            features=engineered.features,
+            shortlist=shortlist,
+            quality_issues=quality_issues,
+        )
+
+    def _persist(self, shortlist: pd.DataFrame, centers: pd.DataFrame) -> None:
+        timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        if self.config.write_to_csv:
+            csv_path = self.config.output_dir / f"{timestamp}_{self.config.csv_filename}"
+            shortlist.to_csv(csv_path, index=False)
+        if self.config.write_to_excel:
+            excel_path = self.config.output_dir / f"{timestamp}_{self.config.excel_filename}"
+            shortlist.to_excel(excel_path, index=False)
+
+        if self.config.write_to_db:
+            engine = self.loader.engine
+            shortlist.to_sql(self.config.shortlist_table, engine, if_exists="replace", index=False)
+            versioned_table = f"{self.config.shortlist_view_versioned_prefix}{timestamp}"
+            shortlist.to_sql(versioned_table, engine, if_exists="replace", index=False)
+            centers.to_sql("target_segment_centers", engine, if_exists="replace", index=False)
+
+
+__all__ = ["AgenticTargetingPipeline", "PipelineArtifacts"]

--- a/backend/agentic_pipeline/quality.py
+++ b/backend/agentic_pipeline/quality.py
@@ -1,0 +1,51 @@
+"""Data quality checks for the targeting pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import pandas as pd
+
+
+@dataclass(slots=True)
+class QualityIssue:
+    level: str
+    message: str
+
+
+class DataQualityChecker:
+    """Runs data quality heuristics and returns human-readable findings."""
+
+    def __init__(self, required_columns: Iterable[str]) -> None:
+        self.required_columns = set(required_columns)
+
+    def run(self, dataset: pd.DataFrame) -> list[QualityIssue]:
+        issues: list[QualityIssue] = []
+        if dataset.empty:
+            issues.append(QualityIssue("critical", "Dataset is empty after loading."))
+            return issues
+
+        missing_cols = self.required_columns.difference(dataset.columns)
+        if missing_cols:
+            issues.append(
+                QualityIssue(
+                    "critical",
+                    f"Missing required columns: {', '.join(sorted(missing_cols))}",
+                )
+            )
+
+        for col in self.required_columns.intersection(dataset.columns):
+            null_ratio = dataset[col].isna().mean()
+            if null_ratio > 0.5:
+                issues.append(
+                    QualityIssue(
+                        "warning",
+                        f"Column '{col}' has {null_ratio:.0%} missing values.",
+                    )
+                )
+
+        return issues
+
+
+__all__ = ["DataQualityChecker", "QualityIssue"]

--- a/backend/agentic_pipeline/ranking.py
+++ b/backend/agentic_pipeline/ranking.py
@@ -1,0 +1,50 @@
+"""Ranking logic for shortlisted companies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+from .config import SegmentWeighting
+
+
+@dataclass(slots=True)
+class RankingResult:
+    scores: pd.Series
+    components: pd.DataFrame
+
+
+class CompositeRanker:
+    """Combines feature-derived metrics into a single score."""
+
+    def __init__(self, weights: SegmentWeighting) -> None:
+        self.weights = weights
+
+    def _normalize(self, series: pd.Series) -> pd.Series:
+        if series.std(ddof=0) == 0:
+            return pd.Series(0.0, index=series.index)
+        normalized = (series - series.mean()) / (series.std(ddof=0) + 1e-9)
+        return normalized.clip(lower=-3, upper=3)
+
+    def compute_components(self, dataset: pd.DataFrame) -> pd.DataFrame:
+        components = pd.DataFrame(index=dataset.index)
+        components["growth"] = self._normalize(dataset.get("revenue_growth", pd.Series(0, index=dataset.index)))
+        components["profitability"] = self._normalize(dataset.get("ebit_margin", pd.Series(0, index=dataset.index)))
+        components["efficiency"] = self._normalize(dataset.get("revenue_per_employee", pd.Series(0, index=dataset.index)))
+        risk_proxy = 1 - dataset.get("equity_ratio", pd.Series(0, index=dataset.index)).fillna(0)
+        components["risk"] = -self._normalize(risk_proxy)
+        data_quality_proxy = dataset.notna().mean(axis=1)
+        components["data_quality"] = data_quality_proxy
+        return components.fillna(0)
+
+    def score(self, dataset: pd.DataFrame) -> RankingResult:
+        components = self.compute_components(dataset)
+        weights = np.array(self.weights.as_sequence())
+        score_values = components.mul(weights, axis=1).sum(axis=1)
+        return RankingResult(scores=score_values.rename("composite_score"), components=components)
+
+
+__all__ = ["CompositeRanker", "RankingResult"]

--- a/backend/agentic_pipeline/segmentation.py
+++ b/backend/agentic_pipeline/segmentation.py
@@ -1,0 +1,51 @@
+"""Segmentation logic for target company selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from sklearn.cluster import KMeans
+from sklearn.preprocessing import StandardScaler
+
+
+@dataclass(slots=True)
+class SegmentationResult:
+    labels: pd.Series
+    cluster_centers: pd.DataFrame
+    inertia: float
+
+
+class Segmenter:
+    """Clusters companies based on engineered features."""
+
+    def __init__(self, n_clusters: int = 6, random_state: int = 42) -> None:
+        self.n_clusters = n_clusters
+        self.random_state = random_state
+        self._scaler: Optional[StandardScaler] = None
+        self._model: Optional[KMeans] = None
+
+    def fit_predict(self, features: pd.DataFrame) -> SegmentationResult:
+        if features.empty:
+            raise ValueError("Cannot segment an empty feature frame.")
+
+        self._scaler = StandardScaler()
+        scaled = self._scaler.fit_transform(features)
+
+        self._model = KMeans(n_clusters=self.n_clusters, random_state=self.random_state, n_init="auto")
+        labels = self._model.fit_predict(scaled)
+
+        centers = pd.DataFrame(
+            self._scaler.inverse_transform(self._model.cluster_centers_),
+            columns=features.columns,
+        )
+        return SegmentationResult(
+            labels=pd.Series(labels, index=features.index, name="segment_id"),
+            cluster_centers=centers,
+            inertia=float(self._model.inertia_),
+        )
+
+
+__all__ = ["Segmenter", "SegmentationResult"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,8 +1,11 @@
 requests>=2.31.0
 pandas>=2.1.0
+numpy>=1.24.0
+scikit-learn>=1.3.0
 sqlalchemy>=2.0.0
 tqdm>=4.66.0
 urllib3>=2.0.0
 supabase>=2.0.0
 psycopg2-binary>=2.9.0
-python-dotenv>=1.0.0 
+python-dotenv>=1.0.0
+openpyxl>=3.1.0

--- a/backend/run_agentic_targeting_pipeline.py
+++ b/backend/run_agentic_targeting_pipeline.py
@@ -1,0 +1,40 @@
+"""Entry point for the agentic targeting pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agentic_pipeline.config import PipelineConfig
+from agentic_pipeline.orchestrator import AgenticTargetingPipeline
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the agentic targeting pipeline")
+    parser.add_argument("--db-path", type=Path, default=Path("allabolag.db"), help="Path to the SQLite database")
+    parser.add_argument("--top", type=int, default=30, help="Number of companies to shortlist")
+    parser.add_argument("--no-db", action="store_true", help="Skip writing results back to the database")
+    parser.add_argument("--no-csv", action="store_true", help="Skip writing CSV outputs")
+    parser.add_argument("--no-excel", action="store_true", help="Skip writing Excel outputs")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = PipelineConfig(
+        db_path=args.db_path,
+        n_top_companies=args.top,
+        write_to_db=not args.no_db,
+        write_to_csv=not args.no_csv,
+        write_to_excel=not args.no_excel,
+    )
+    pipeline = AgenticTargetingPipeline(config)
+    artifacts = pipeline.run()
+
+    issues = [issue.message for issue in artifacts.quality_issues]
+    print(json.dumps({"quality_issues": issues, "shortlist_size": len(artifacts.shortlist)}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/agent_targeting_strategy.md
+++ b/docs/agent_targeting_strategy.md
@@ -1,0 +1,142 @@
+# Agent-Orchestrated Target Selection and Due Diligence Plan
+
+## 1. Current Capabilities Recap
+- The backend already assembles enriched company views that merge KPIs, financial accounts, and enrichment metadata into Excel-ready reports (`final_filter_companies.py`).【F:backend/final_filter_companies.py†L13-L94】
+- AI scoring currently evaluates filtered companies with a single OpenAI call per record to produce qualitative insights (`analyze_top_companies.py`).【F:backend/analyze_top_companies.py†L9-L124】
+- The broader platform combines scraping, KPI calculation, segmentation assets, and Supabase-backed storage that feeds a Next.js frontend for exploration.【F:README.md†L5-L143】
+
+These pieces form the foundation for a richer, agent-coordinated workflow that can surface, evaluate, and report on the most attractive targets in a repeatable manner.
+
+## 2. Objectives for the Enhanced Solution
+1. **Segment Intelligently** – Systematically cluster and rank companies by strategic fit, growth profile, and operational similarity.
+2. **Surface Top Contenders** – Produce a focused short list with transparent scoring logic and explainability.
+3. **Automate Due Diligence** – Use specialized agents to build market and financial briefs from public data with minimal manual effort.
+4. **Operationalize** – Deliver outputs in database tables, CSV/Excel artifacts, and Supabase views consumable by the frontend and downstream tooling.
+
+## 3. Data Foundation & Feature Store Plan
+1. **Ingestion**
+   - Continue scraping Allabolag.se data (`fetch_allabolag.py`) into `companies`, `company_accounts`, and `company_kpis` staging tables.
+   - Introduce scheduled pulls for complementary datasets (e.g., news sentiment APIs, job postings, patent filings) stored in new Supabase tables (`company_news_sentiment`, `company_hiring_trends`).
+2. **Normalization & Feature Engineering**
+   - Extend the enrichment pipeline to compute normalized metrics (e.g., revenue percentile within segment, 3-year CAGR, cash conversion cycle, web traffic estimates) and store results in a `company_feature_store` table with a version tag.
+   - Add binary/continuous signals for strategic theses (e.g., export intensity, digital readiness, sustainability indices) using third-party datasets or heuristic scoring agents.
+3. **Quality Gates**
+   - Reuse `final_filter_companies.py` filters as baseline, but parameterize thresholds so agents can adjust guardrails per campaign while logging overrides for auditability.【F:backend/final_filter_companies.py†L48-L56】
+
+## 4. Target Segmentation Framework
+1. **Segment Profiles**
+   - Define canonical segment templates (e.g., High-Growth SaaS, B2B Industrials, E-commerce Niche Players) with required metrics ranges and qualitative descriptors.
+   - Store templates in Supabase (`target_segment_templates`) with JSON schema capturing metric thresholds, keywords, and weighting vectors.
+2. **Clustering & Matching**
+   - Apply semi-supervised clustering (e.g., HDBSCAN or k-prototypes) on the feature store to identify natural cohorts.
+   - Use cosine similarity between company feature vectors and template vectors to assign fit scores, generating a `company_segment_fit` table with per-segment probabilities.
+3. **Top Contender Selection**
+   - Combine quantitative fit score, growth momentum, risk-adjusted profitability, and data completeness into a composite ranking algorithm.
+   - Publish the ranked list into `target_company_shortlist_v{date}` tables. Persist the underlying factors for transparency.
+
+## 5. Agent Task Architecture
+### 5.1 Orchestrator Agent
+- Oversees pipeline execution, kicks off segment scoring runs, and coordinates specialist agents.
+- Maintains campaign context (investment thesis, geography focus, target size) to parameterize downstream tasks.
+
+### 5.2 Data Validation Agent
+- Verifies freshness of source tables and checks missing data patterns.
+- Generates data quality reports and halts pipeline if anomalies are detected (e.g., sudden revenue drops due to scraping errors).
+
+### 5.3 Segmentation Analyst Agent
+- Reviews feature distributions, adjusts thresholds, and documents rationale for segment assignments.
+- Suggests new segment templates when clusters exhibit emergent behavior.
+
+### 5.4 Market Intelligence Agent
+- Pulls external public data: industry reports, news articles, web traffic, social signals.
+- Summarizes market positioning, competitive landscape, and macro tailwinds/headwinds for each shortlisted company.
+
+### 5.5 Financial Analyst Agent
+- Deep-dives into financial statements: margin trends, cash flow health, leverage, and forecast projections.
+- Runs scenario stress tests and calculates valuation multiples using comparable sets derived from the segment cohort.
+
+### 5.6 Risk & Compliance Agent
+- Screens for red flags: legal disputes, sanction lists, ESG controversies, credit alerts.
+- Produces a risk score and recommended follow-up actions.
+
+### 5.7 Synthesis & Reporting Agent
+- Assembles agent findings into structured investment memos, populates Supabase tables, and exports PDF/Excel summaries.
+- Writes insights back into `ai_company_analysis` and generates highlight cards for the frontend dashboard.
+
+## 6. Workflow Automation Blueprint
+1. **Campaign Kick-off**
+   - Orchestrator ingests campaign brief → updates configuration tables.
+2. **Data Refresh & QA**
+   - Data Validation Agent ensures the latest feature store snapshot passes quality checks.
+3. **Segmentation & Ranking**
+   - Segmentation Analyst Agent computes fit scores → orchestrator writes `target_company_shortlist`.
+4. **Agentic Due Diligence Sprint**
+   - For each candidate (batched to manage API costs):
+     1. Market Intelligence Agent compiles external brief.
+     2. Financial Analyst Agent updates financial scorecard (DCF, comparables).
+     3. Risk Agent runs compliance screenings.
+   - Agents exchange intermediate artifacts via Supabase storage or object store for traceability.
+5. **Synthesis & Delivery**
+   - Reporting Agent merges outputs into campaign package (dashboard tiles, memo PDFs, Excel exports).
+   - Notifications triggered (e.g., Slack, email) to stakeholders with summary and next actions.
+
+## 7. Implementation Roadmap
+1. **Phase 0 – Foundations (1-2 weeks)**
+   - Document existing data schemas, ensure repeatable data refresh jobs.
+   - Stand up Supabase tables for feature store, segment templates, agent logs.
+2. **Phase 1 – Segmentation Upgrade (2-3 weeks)**
+   - Build feature engineering scripts, develop clustering & template matching notebooks.
+   - Deploy segmentation service/API callable by agents.
+3. **Phase 2 – Agent Framework (3-4 weeks)**
+   - Integrate orchestration platform (e.g., LangGraph, crewAI) with specialized agent prompts and toolsets.
+   - Implement Market & Financial agents with access to scraping utilities, financial APIs, and modeling templates.
+4. **Phase 3 – Reporting & Frontend Integration (2 weeks)**
+   - Extend `ai_company_analysis` schema to capture multi-agent outputs (market summary, financial verdict, risk notes).【F:backend/analyze_top_companies.py†L13-L122】
+   - Update frontend to surface new shortlists, agent memos, and KPI comparisons (future PR).
+5. **Phase 4 – Continuous Improvement**
+   - Add reinforcement signals (user feedback loops), automate benchmarking, and refine prompts/models based on outcomes.
+
+## 8. Governance & Observability
+- Maintain an `agent_run_log` table capturing prompts, outputs, latency, and confidence.
+- Implement cost tracking per campaign and agent to monitor API spend.
+- Establish human-in-the-loop checkpoints where analysts can override scores or flag anomalies before final memos are published.
+
+## 9. Deliverables Summary
+- **Documentation**: Campaign playbook, agent prompt templates, configuration schemas.
+- **Data Assets**: Feature store snapshots, segment fit tables, shortlist tables, agent logs.
+- **Dashboards**: Target pipeline tracker with drill-down into market, financial, and risk findings.
+- **Automation**: Scheduled orchestrator workflows with restart/resume capabilities.
+
+## 10. Implementation Snapshot
+- **Agentic Targeting Pipeline** – Executable orchestrator that loads enriched company data, engineers features, runs clustering-based segmentation, computes composite scores, and generates deterministic market & financial briefs (`backend/agentic_pipeline`).【F:backend/agentic_pipeline/orchestrator.py†L1-L94】【F:backend/agentic_pipeline/analysis.py†L1-L88】
+- **Operational Entry Point** – CLI for analysts or automation runners to execute the full shortlist workflow and persist outputs to SQLite/CSV/Excel (`backend/run_agentic_targeting_pipeline.py`).【F:backend/run_agentic_targeting_pipeline.py†L1-L40】
+- **Dependencies** – Requirements file updated with numerical and workbook packages needed for clustering, scoring, and Excel exports (`backend/requirements.txt`).【F:backend/requirements.txt†L1-L10】
+
+This plan now pairs strategic guidance with the concrete agentic pipeline implementation, positioning the branch for integration into `main` once validated end-to-end.
+
+## 11. How to Run and Test the Pipeline
+1. **Install dependencies**
+   ```bash
+   cd backend
+   pip install -r requirements.txt
+   ```
+   Ensure you are using Python 3.10+ so the `dataclasses` and typing features used by the pipeline are available.
+2. **Verify syntax**
+   Run the same compilation check used in CI to catch import or syntax errors early:
+   ```bash
+   python -m compileall agentic_pipeline run_agentic_targeting_pipeline.py
+   ```
+3. **Execute the pipeline**
+   From the repository root (or inside `backend/`), run the CLI entry point. Point `--db-path` to the SQLite database that contains `company_kpis`, `company_accounts`, and `companies_enriched` tables.
+   ```bash
+   python backend/run_agentic_targeting_pipeline.py --db-path allabolag.db --top 30
+   ```
+   Use `--no-db`, `--no-csv`, or `--no-excel` flags if you want to skip writing outputs to those destinations during dry runs.
+4. **Review outputs**
+   - **Terminal** – The command prints a JSON summary listing any data-quality warnings and the size of the produced shortlist.
+   - **Database** – When `--no-db` is omitted, new tables/views defined in the pipeline configuration are created/updated inside the provided SQLite database.
+   - **Filesystem** – Unless disabled, CSV and Excel files are written to `outputs/agentic_targeting/` with timestamped filenames for traceability.
+5. **Validate data quality**
+   The pipeline emits structured issues (e.g., missing tables, sparse data) collected from the quality gate. Treat any non-empty `quality_issues` entries as blockers until investigated.
+
+Following the steps above will recreate the same end-to-end flow that the automated orchestration agent runs, giving you confidence that segmentation, scoring, and reporting behave as expected before merging the branch.


### PR DESCRIPTION
## Summary
- add agentic pipeline package that loads enriched company data, engineers features, clusters companies, and ranks a shortlist
- create CLI runner to execute the segmentation and due diligence workflow and persist results to db/csv/excel
- extend requirements to include numerical, clustering, and excel export dependencies and document the implementation snapshot
- document how to run and test the agentic targeting pipeline end to end

## Testing
- python -m compileall backend/agentic_pipeline backend/run_agentic_targeting_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e4297528d8832094bc12866eb94eed